### PR TITLE
Better Errors

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,4 @@
-(defproject com.bigml/closchema "0.1.7"
+(defproject com.bigml/closchema "0.1.8"
   :description "Implements the JSON Schema specification."
-  :dependencies [[org.clojure/clojure "1.3.0"]
+  :dependencies [[org.clojure/clojure "1.4.0"]
                  [org.clojure/data.json "0.1.2"]])
-

--- a/src/closchema/core.clj
+++ b/src/closchema/core.clj
@@ -118,15 +118,18 @@
 ;; If not, we pick one of the types (the first one, because why not?)
 ;; and put it through validation again to populate the error queue
 (defmethod validate* ::union [schema instance]
-  (let [current-errors #(count (deref (:errors *validation-context*)))
+  (let [current-errors #(count @(:errors *validation-context*))
         error-counts (map #(binding [*validation-context* {:errors (ref '())
                                                            :path (ref [])}]
                              (validate % instance)
-                             {:errors (current-errors) :schema %})
+                             {:error-count (current-errors)
+                              :errors @(:errors *validation-context*)
+                              :schema %})
                           (:type schema))]
-    (when-not (some #(= 0 (:errors %)) error-counts)
-      (invalid :matches-no-type-in-union {:properties (:type schema)}))))
-
+    (when-not (some #(= 0 (:error-count %)) error-counts)
+      (let [errors (sort-by :error-count error-counts)]
+        (invalid :matches-no-type-in-union
+                 {:instance instance :errors (:errors (first errors))})))))
 
 (def ^{:doc "Known basic types."}
      basic-type-validations


### PR DESCRIPTION
This gives us nicer error messages for union types.  Basically, you get the `:instance` that failed along with the `:errors` for the thing in the union that came closest to matching (on a number-of-errors basis).

Here's a sample:

``` none
2012-07-20 17:35:09,202 WARN  wintermute.rest.client - JSON validation error for :dataset: 
({:key :matches-no-type-in-union, :ref nil, 
  :data {:instance {:preferred true, :summary {:median 27.16667, :minimum 0, :sum_squares 153720, :missing_count 0, :bins [[0.5 4] [2.5 4] [4.5 4] [6.5 4] [8.5 4] [10.6 5] [12.5 6] [14.5 6] [16.5 6] [18.5 6] [20.5 6] [22.5 6] [24.5 6] [26.5 6] [28.5 6] [30.5 6] [32.5 6] [34.4 5] [36.5 4] [38.5 4] [40.5 4] [42.5 4] [44.5 4] [46.5 4] [48.5 4] [50.5 4] [52.5 4] [54.5 4] [56 2] [57 2] [58 2] [59 2]], :sum 4080, :population 144, :maximum 59, :splits [1.75 4 6.25 8.5 10.64575 12.16667 13.66667 15.16667 16.66667 18.16667 19.66667 21.16667 22.66667 24.16667 25.66667 27.16667 28.66667 30.16667 31.66667 33.16667 34.76393 37 39.25 41.5 43.75 46 48.25 50.5 52.75 55 57.25]}, :optype "numeric", :datatype "minute", :parent_ids ["000001"], :auto_generated true, :name "field2 (minute)"}, 
         :errors ({:key :value-not-in-enum, :ref nil, :data {:enum ["integer" "int8" "int16" "int32" "int64" "float" "double" "day" "month" "year" "hour" "sec" "milli" "day-of-week" "day-of-month"], :value "minute"}, :path [nil]})}, :path [nil]})
```
