### PR TITLE
Support the required format of the latest schema version

### DIFF
--- a/src/closchema/core.clj
+++ b/src/closchema/core.clj
@@ -160,6 +160,7 @@
 (defmethod ^:private validate* :object
   [{properties-schema :properties
     additional-schema :additionalProperties
+    required :required
     parent :extends
     :as schema} instance]
 
@@ -170,6 +171,15 @@
     (if (vector? parent)
       (doseq [s parent] (validate s instance))
       (validate parent instance)))
+
+  ;; validate required properties defined in schema
+  (when (vector? required)
+    (doseq [property-name required]
+      (let [prop-exists (and (map? instance)
+                             (or (contains? instance property-name)
+                                 (contains? instance (keyword property-name))))]
+        (when-not prop-exists
+          (invalid property-name :required)))))
 
   ;; validate properties defined in schema
   (doseq [[property-name property-schema] properties-schema]

--- a/test/closchema/test/core.clj
+++ b/test/closchema/test/core.clj
@@ -360,6 +360,33 @@
 (deftest validate-type-array-with-number-input
          (is (not (validate {:type "array" :items {:type "integer"}} 1))))
 
+;; Test all combinations of :required array
+(deftest validate-with-new-required-keys
+  ;; With no :required params, the key is not required
+  (let [schema {:type "object"
+                :properties {:id {:type "integer"}}}]
+    (is (validate schema {})))
+
+  ;; With an empty :required param, the key is not required
+  (let [schema {:type "object" :required []
+                :properties {:id {:type "integer"}}}]
+    (is (validate schema {})))
+
+  ;; With a :required param, the key is required
+  (let [schema {:type "object" :required ["id"]
+                :properties {:id {:type "integer"}}}]
+    (is (not (validate schema {}))))
+
+  ;; With a :required param, a keyword key is accepted
+  (let [schema {:type "object" :required ["id"]
+                :properties {:id {:type "integer"}}}]
+    (is (validate schema {:id 12345})))
+
+  ;; With a :required param, a string key is accepted
+  (let [schema {:type "object" :required ["id"]
+                :properties {:id {:type "integer"}}}]
+    (is (validate schema {"id" 12345}))))
+
 ;; Test all combinations of :optional and :required
 (deftest validate-with-required-or-optional-keys
   ;; With no :required or :optional params, the key is not required


### PR DESCRIPTION
The latest JSON Scheme has changed, it says the required flag can only be included in object type schemas, and the following applies:

```
5.4.3.  required

5.4.3.1.  Valid values

The value of this keyword MUST be an array. This array MUST have at least one element.
Elements of this array MUST be strings, and MUST be unique.

5.4.3.2.  Conditions for successful validation

An object instance is valid against this keyword if its property set contains all elements in this
keyword's array value.
```

This patch makes it possible to use both styles, but doesn't do much validation for input. Let me know if you're interested in merging and if I need to clean it up. This is a bit of a showstopper for me, because I don't want to use the outdated schema style for new project and still want to get the required fields processed correctly.
