### PR TITLE
Should not accept an optional property with value null (unless null type)

### DIFF
--- a/src/closchema/core.clj
+++ b/src/closchema/core.clj
@@ -152,14 +152,13 @@
 (defn- check-basic-type
   "Validate basic type definition for known types."
   [{t :type :as schema} instance validators]
-  (or (and (nil? instance) (not (required? schema)))
-      (let [t (or t default-type)
-            types (if (coll? t) t (vector t))]
-        (or (reduce some
-                    (map (fn [t] ((validators t) instance))
-                         types))
-            (invalid :type {:expected (map str types)
-                            :actual (str (type instance))})))))
+  (let [t (or t default-type)
+        types (if (coll? t) t (vector t))]
+    (or (reduce some
+                (map (fn [t] ((validators t) instance))
+                     types))
+        (invalid :type {:expected (map str types)
+                        :actual (str (type instance))}))))
 
 
 (defn- common-validate [schema instance validators]

--- a/test/closchema/test/core.clj
+++ b/test/closchema/test/core.clj
@@ -63,8 +63,8 @@
         "should not accept when required property is not present")
     (is (not (validate s {:id "1" :name "bag"}))
         "should not accept when property type is incorrect")
-    (is (validate s {:id 1 :name "test" :description nil})
-        "should accept an optional property with value null")))
+    (is (validate s {:id 1 :name "test"})
+        "should accept a missing property if optional")))
 
 (deftest validate-false-additional-properties
   (let [s (merge base-schema {:additionalProperties false})]
@@ -180,7 +180,8 @@
 
 (deftest validate-common-string
   (let [s {:type "string"}]
-    (is (validate s "foobar") "should validate with string")))
+    (is (validate s "foobar") "should validate with string")
+    (is (not (validate s nil)) "not validate if nil")))
 
 (deftest validate-minimum-string
   (let [s {:type "string" :minLength 3}]
@@ -212,7 +213,8 @@
 (deftest validate-common-numbers
   (let [s {:type "number"}]
     (is (and (validate s 1) (validate s -2) (validate s 3.5)) "is a number")
-    (is (not (validate s "2")) "not a number")))
+    (is (not (validate s "2")) "not a number")
+    (is (not (validate s nil)) "not validate nil")))
 
 (deftest validate-max-number
   (let [s {:type '"number" :maximum 5 :exclusiveMaximum true}


### PR DESCRIPTION
It is my understanding that null values should be invalid, unless the `null` type is allowed. This matches (failing) examples like `{"type": "string"}` with `null` on http://jsonschemalint.com/draft4/.

However currently

``` clj
user=> (schema/validate {:type "string"} nil)
true
```

This commit changes the behaviour to disallow `null`, removing code previously allowing `null` of the property was optional (maybe as specified in an older draft?).

I have only added tests for `string` and `integer` types so far.
